### PR TITLE
Fixed custom property extraction

### DIFF
--- a/src/main/groovy/adop/cartridge/properties/CartridgeProperties.groovy
+++ b/src/main/groovy/adop/cartridge/properties/CartridgeProperties.groovy
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Properties;
 import adop.cartridge.properties.exceptions.*;
+import java.lang.IllegalArgumentException;
 
 public class CartridgeProperties {
     
@@ -64,11 +65,16 @@ public class CartridgeProperties {
     * @param properties properties seperated by \r\n.
     **/
     private void loadProperties(String properties){
-        String[] lines = properties.split(LINE_ENDINGS_REGEX);
-        
-        for(line in lines){
-            String[] property = line.split(PROPERTY_DELIMITER);
-            this.properties.setProperty(property[0],property[1]); 	
+        if (!properties.equals("") {   
+            String[] lines = properties.split(LINE_ENDINGS_REGEX);
+            for(line in lines){
+                String[] property = line.split(PROPERTY_DELIMITER);
+                if (property.length == 2) {
+                    this.properties.setProperty(property[0],property[1]); 	
+                } else {
+                    throw new IllegalArgumentException( "line is not key value pair: " + line)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
adop-cartridge-docker build failed if no custom properties were entered.
It also failed if the data entered was not in a "key=value" format.
This change ignores the function if nothing is entered, and throws an error if the string is not a key pair.